### PR TITLE
Removing Shell.js from project - now uses node's built in FS Copy.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "start": "cd demo/ && node demo.js && cd ../",
-    "test": "nyc ava",
+    "test": "nyc ava --serial",
     "pub": "npm version patch && npm publish && git push",
     "sync": "git ac && git pull --rebase && git push"
   },
@@ -33,15 +33,14 @@
     "inform"
   ],
   "dependencies": {
-    "chalk": "^1.1.2",
-    "shelljs": "^0.7.0"
+    "chalk": "^2.4.1",
+    "fs-extra": "^7.0.1"
   },
   "devDependencies": {
-    "ava": "github:sindresorhus/ava",
-    "codecov": "^1.0.1",
-    "nyc": "^6.4.4",
-    "rimraf": "^2.5.2",
-    "tap": "^5.7.1"
+    "ava": "^0.25.0",
+    "codecov": "^3.1.0",
+    "nyc": "^13.1.0",
+    "tap": "^12.1.0"
   },
   "bugs": {
     "url": "https://github.com/dmitriz/gently-copy/issues"

--- a/test.js
+++ b/test.js
@@ -1,96 +1,118 @@
 // test.js
-import fs from 'fs'
-// import path from 'path'
-import rimraf from 'rimraf'
+const fs = require('fs-extra')
 import test from 'ava'
-
 import fn from './'
 
-function read (file) {
-  return fs.readFileSync(file, 'utf8')
+function sleep(ms) {
+	return new Promise(resolve => {
+		setTimeout(resolve, ms)
+	})
+}
+/**
+ * Attempts to read a file, returns contents.
+ * During testing it was found that although the copy had completed, the file wasn't accessible on the file system (even upon an SSD).
+ * Read now tries 5 times, waiting 500ms after each attempt.  On a SSD this was found to take 2 attempts - even for small files.
+ * @param {*} file File to Read
+ * @param {*} attempts Number of attempts (defaults to 5)
+ */
+async function read(file, attempts = 5) {
+	try {
+		const content = fs.readFileSync(file, 'utf8')
+		return content
+	} catch (error) {
+		await sleep(500)
+		if (attempts > 0) {
+			return read(file, attempts - 1)
+		}
+		throw (error)
+	}
+
 }
 
-function write (file, data) {
-  return fs.appendFileSync(file, data, 'utf8')
+function write(file, data) {
+	return fs.appendFileSync(file, data, 'utf8')
 }
-
-function mkdir (dir) {
-  return fs.mkdirSync(dir)
+/** */
+function mkdir(dir) {
+	return fs.mkdirSync(dir)
 }
 
 test.beforeEach(t => {
-  rimraf.sync('tmp')
-  fs.mkdirSync('tmp')
+	fs.emptyDirSync('tmp')
+	fs.ensureDirSync('tmp')
 })
 
 test.afterEach(t => {
-  rimraf.sync('tmp')
+	fs.emptyDirSync('tmp')
 })
 
 /*
  *  === Single file or directory copy ===
  */
-test('copy one file to new name', t => {
-  fn('LICENSE', 'tmp/LICENSE')
-  t.is(read('LICENSE'), read('tmp/LICENSE'))
+test('copy one file to new name', async t => {
+	fn('LICENSE', 'tmp')
+	t.is(await read('LICENSE'), await read('tmp/LICENSE'))
+
 })
 
-test('copy one file to existing directory', t => {
-  mkdir('tmp/newdir')
-  fn('LICENSE', 'tmp/newdir')
-  t.is(read('LICENSE'), read('tmp/newdir/LICENSE'))
+test('copy one file to existing directory', async t => {
+	mkdir('tmp/newdir')
+	fn('LICENSE', 'tmp/newdir')
+	t.is(await read('LICENSE'), await read('tmp/newdir/LICENSE'))
 })
 
-test('copy one directory preserving file structure', t => {
-  mkdir('tmp/dir_old')
-  write('tmp/dir_old/file', 'mytext')
-  fn('tmp/dir_old', 'tmp/dir_new')
-  t.is(read('tmp/dir_new/file'), 'mytext')
+test('copy one directory preserving file structure', async t => {
+	mkdir('tmp/dir_old')
+	write('tmp/dir_old/file', 'mytext')
+	await fn('tmp/dir_old', 'tmp/dir_new')
+	t.is(await read('tmp/dir_new/file'), 'mytext')
 })
 
 /*
  *  === Multiple file or directory copy ===
  */
 
-test('copy multiple files and directories', t => {
-  mkdir('tmp/dir')
-  mkdir('tmp/dir/subdir')
-  write('tmp/dir/subdir/file', 'mytext')
+test('copy multiple files and directories', async t => {
+	mkdir('tmp/dir')
+	mkdir('tmp/dir/subdir')
+	write('tmp/dir/subdir/file', 'mytext')
 
-  fn(['LICENSE', 'package.json', 'dir/subdir'], 'tmp')
-  t.is(read('LICENSE'), read('tmp/LICENSE'))
-  t.is(read('package.json'), read('tmp/package.json'))
-  t.is(read('tmp/dir/subdir/file'), 'mytext')
+	fn(['LICENSE', 'package.json', 'tmp/dir/subdir'], 'tmp')
+	t.is(await read('LICENSE'), await read('tmp/LICENSE'), 'LICENSE File incorrect')
+	t.is(await read('package.json'), await read('tmp/package.json'), 'tmp/package.json File incorrect')
+	t.is(await read('tmp/dir/subdir/file'), 'mytext', 'tmp/dir/subdir/file File incorrect')
 })
 
 /*
  *  === Non-existant directory copy ===
  */
-test('copy one file into non-existing directory', t => {
-  fn('LICENSE', 'tmp/dir_nonexist/newfile')
+test('copy one file into non-existing directory', async t => {
+	await fn('LICENSE', 'tmp/dir_nonexist/newfile')
+	t.is(await fs.exists('tmp/dir_nonexist/newfile/LICENSE'), true)
 })
 
 /*
  *  === (Non) overwriting ===
  */
-test('do not overwrite existing file', t => {
-  write('tmp/newfile', 'mytext')
-  fn('LICENSE', 'tmp/newfile')
-  t.is(read('tmp/newfile'), 'mytext')
+test('do not overwrite existing file', async t => {
+	write('tmp/newfile', 'mytext')
+	await fn('LICENSE', 'tmp/newfile')
+	t.is(await read('tmp/newfile'), 'mytext')
 })
 
-test('do not overwrite existing directory', t => {
-  mkdir('tmp/dir_old')
-  write('tmp/dir_old/file', 'mytext')
-  fn('LICENSE', 'tmp/dir_old')
-  t.is(read('tmp/dir_old/file'), 'mytext')
+test('do not overwrite existing directory', async t => {
+	mkdir('tmp/dir_old2')
+	write('tmp/dir_old2/file', 'mytext')
+	await fn('LICENSE', 'tmp/dir_old2')
+	t.is(await read('tmp/dir_old2/file'), 'mytext')
 })
-
 /*
  *  === Overwrite option
  */
-test('overwrite existing file if option.overwrite === true', t => {
-  write('tmp/newfile', 'mytext')
-  fn('LICENSE', 'tmp/newfile', {overwrite: true})
-  t.is(read('tmp/newfile'), read('LICENSE'))
+test('overwrite existing file if option.overwrite === true', async t => {
+	write('tmp/newfile', 'mytext')
+	await fn('LICENSE', 'tmp/newfile', {
+		overwrite: true
+	})
+	t.is(await read('tmp/newfile'), await read('LICENSE'))
 })


### PR DESCRIPTION
Have attempted to remove the shell.js dependency as node has built in copy functions.

Found one of the tests confusing : 

```
test('copy one file to new name', t => {
  fn('LICENSE', 'tmp/LICENSE')
  t.is(read('LICENSE'), read('tmp/LICENSE'))
})
```

the documentation for the library says that the second option should be the directory name - so this test should create a tmp/LICENSE/LICENSE file? but the test (currently) creates a tmp/LICENSE file - which isn't what the documentation describes?  Is there is a special case if the source element is a file (and only a single) because there could be a situation where copy attempts to copy where a folder already exists?

As 2 of these tests were failing, and there seemed to be a discrepancy between the documentation and operation, then I tried to keep functionality as documented.

Can you confirm that you are happy with these changes?
